### PR TITLE
[5.2] fix paginate parameter $colunms is not working

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -350,7 +350,7 @@ class Builder
     {
         $query = $this->toBase();
 
-        $total = $query->getCountForPagination();
+        $total = $query->getCountForPagination($columns);
 
         $this->forPage(
             $page = $page ?: Paginator::resolveCurrentPage($pageName),


### PR DESCRIPTION
$colunms is not passed to the getCountForPagination() function, resulting distinct count can't work.